### PR TITLE
Correct readme for markAsRead use and use openjdk11 for travis tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ deploy:
     on:
       repo: SlothLabs/kotlin-mail
       branch: master
-      jdk: oraclejdk8
+      jdk: openjdk11
   - provider: script
     script: sh $TRAVIS_BUILD_DIR/.travis/deploy.sh
     skip_cleanup: true
     on:
       repo: SlothLabs/kotlin-mail
       tags: true
-      jdk: oraclejdk8
+      jdk: openjdk11
   - provider: releases
     api_key: $GITHUB_OAUTH_TOKEN
     skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ imap(connectionInfo) {
             +subject("Only a Test")
             +(header("Content-Type", "text/html") or sizeIsAtLeast(1024))
             +sentOnOrBefore(Date())
-            markAsRead(true) // notice the lack of unary plus, default: false
+            markAsRead = true // notice the lack of unary plus, default: false
         }
 
         results.forEach {


### PR DESCRIPTION
Had forgotten to fix the readme with regard to the markAsRead usage when I decided to use a property instead of a method call and use openjdk11 for the other tasks in the TravisCI pipeline.